### PR TITLE
Add submodules option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,11 @@ inputs:
     description: "Ref to use"
     default: ""
     type: string
+  submodules:
+    description: Works as stated in actions/checkout, but the default value is recursive
+    required: false
+    type: string
+    default: recursive
 
 # Note:
 # - inputs.* should be manually mapped to INPUT_* due to https://github.com/actions/runner/issues/665
@@ -25,6 +30,7 @@ runs:
         PATH_TO_USE: ${{ inputs.path }}
         REPOSITORY: ${{ inputs.repository }}
         REF: ${{ inputs.ref }}
+        SUBMODULES: ${{ inputs.submodules }}
       run: |
         set -eu
         if ! command -v bash >/dev/null; then

--- a/main.sh
+++ b/main.sh
@@ -194,6 +194,13 @@ else
     g retry git checkout --force "${GITHUB_REF}"
 fi
 
+# Init submodules
+if [[ "${SUBMODULES}" == "true" ]]; then
+    g retry git submodule update --init --force --depth=1
+elif [[ "${SUBMODULES}" == "recursive" ]]; then
+    g retry git submodule update --init --force --depth=1 --recursive
+fi
+
 case "${host_os}" in
     # error: could not lock config file C:/tools/cygwin/home/runneradmin/.gitconfig: No such file or directory
     windows) g git config --global --add safe.directory "${wd}" || : ;;


### PR DESCRIPTION
This is an important parameter to have.  The context here is a build error shows up on ExecuTorch https://github.com/pytorch/executorch/actions/runs/12084054206/job/33698428919 where it couldn't find its submodule dependencies.

After this lands, a corresponding fix on https://github.com/pytorch/test-infra/pull/5995 is also needed to enable this.